### PR TITLE
Refactor: Concurrent processing of logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,10 @@ func main() {
 		r.Post("/", h.HandleLogRequest)
 	})
 
-	go h.SyncAtIntervals()
+	go h.CollectLogs()
+
+	// TODO: This does not work with current concurrency logic
+	//go h.SyncAtIntervals()
 
 	// Start the server
 	log.Infof("Starting server on port: %d", 3000)

--- a/main.go
+++ b/main.go
@@ -46,8 +46,7 @@ func main() {
 
 	go h.CollectLogs()
 
-	// TODO: This does not work with current concurrency logic
-	//go h.SyncAtIntervals()
+	go h.SyncAtIntervals()
 
 	// Start the server
 	log.Infof("Starting server on port: %d", 3000)

--- a/pkg/log/handler.go
+++ b/pkg/log/handler.go
@@ -2,64 +2,49 @@ package log
 
 import (
 	"batch-logger/pkg/utils"
-	"bytes"
-	"encoding/json"
-	"fmt"
 	log "github.com/sirupsen/logrus"
 	"net/http"
 	"time"
 )
 
-type Log struct {
-	UserId int     `json:"user_id"`
-	Total  float64 `json:"total"`
-	Title  string  `json:"title"`
-	Meta   struct {
-		Logins []struct {
-			Time time.Time `json:"time"`
-			Ip   string    `json:"ip"`
-		} `json:"logins"`
-		PhoneNumbers struct {
-			Home   string `json:"home"`
-			Mobile string `json:"mobile"`
-		} `json:"phone_numbers"`
-	} `json:"meta"`
-	Completed bool `json:"completed"`
-}
-
 type Handler struct {
-	BatchSize      int    // Maximum batch size
 	BatchInterval  int    // Interval in seconds at which syncing should happen
 	TargetEndpoint string // Target endpoint where JSON arrays should we eventually written
-	payloads       []Log
+	payloads       Payloads
 }
 
 func CreateHandler(batchSize, batchInterval int, targetEndpoint string) Handler {
 	return Handler{
-		BatchSize:      batchSize,
 		BatchInterval:  batchInterval,
 		TargetEndpoint: targetEndpoint,
+		payloads: Payloads{
+			BatchSize: batchSize,
+			logs:      make(chan Log),
+		},
 	}
 }
 
-func (h *Handler) AddPayload(payload Log) []Log {
-	h.payloads = append(h.payloads, payload)
-
-	// Check if batch size is exceeded or not
-	if len(h.payloads) >= h.BatchSize {
-		// Call sync payloads concurrently
-		go h.syncPayloadsToPostEndpoint()
-	}
-
-	return h.payloads
-}
-
-// SyncAtIntervals Sync Payload Data in intervals to the provided endpoint
 func (h *Handler) SyncAtIntervals() {
+	// Sync Payload Data in intervals to the provided endpoint
 	for range time.Tick(time.Second * time.Duration(h.BatchInterval)) {
-		if len(h.payloads) > 0 {
-			// Call sync payloads concurrently
-			go h.syncPayloadsToPostEndpoint()
+		if len(h.payloads.logs) > 0 {
+			// Concurrently call to sync data to post endpoint
+			go syncPayloadsToTargetEndpoint(nil, h.TargetEndpoint)
+		}
+	}
+}
+
+func (h *Handler) CollectLogs() {
+	// Collect logs from Handler's payload channel and sync when data is full
+	payloads := make([]Log, 0, h.payloads.BatchSize)
+	for {
+		payload := <-h.payloads.logs
+		payloads = append(payloads, payload)
+
+		if len(payloads) >= h.payloads.BatchSize {
+			// Concurrently call to sync data to post endpoint
+			go syncPayloadsToTargetEndpoint(payloads, h.TargetEndpoint)
+			payloads = make([]Log, 0, h.payloads.BatchSize)
 		}
 	}
 }
@@ -68,7 +53,7 @@ func (h *Handler) HandleLogRequest(w http.ResponseWriter, r *http.Request) {
 	// Fetch Payload from context and store in memory
 	ctx := r.Context()
 	payload := ctx.Value(utils.GetPayloadRequestId(ctx)).(Log)
-	h.AddPayload(payload)
+	h.payloads.Add(payload)
 
 	// Write response
 	w.WriteHeader(200)
@@ -77,37 +62,4 @@ func (h *Handler) HandleLogRequest(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Response failed with error: %s", err)
 		return
 	}
-}
-
-func (h *Handler) syncPayloadsToPostEndpoint() {
-	log.Info("Syncing logs to POST Endpoint")
-
-	payloadsLength := len(h.payloads)                           // Number of elements in slice
-	postBody, err := json.Marshal(h.payloads[0:payloadsLength]) // Prepare data for request
-	h.payloads = h.payloads[payloadsLength:]                    // remove elements
-	if err != nil {
-		// Exit the application if JSON can not be serialized
-		panic("JSON could not be marshalled")
-	}
-
-	start := time.Now()
-
-	for count := 0; count < 3; count++ {
-		res, err := http.Post(h.TargetEndpoint, "application/json", bytes.NewBuffer(postBody))
-
-		// If err is nil then request was successful
-		if err == nil {
-			log.Infof("Synced Batch of Size %d which returned status code %d and took %s", payloadsLength, res.StatusCode, time.Since(start))
-			break
-		}
-
-		// If syncing failed for 3 times in a row exit the application
-		if count == 2 {
-			panic(fmt.Sprintf("Log syncing failed with error: %s", err))
-		}
-
-		// Wait for 2 seconds before retrying
-		time.Sleep(time.Second * time.Duration(2))
-	}
-
 }

--- a/pkg/log/payloads.go
+++ b/pkg/log/payloads.go
@@ -20,10 +20,15 @@ type Log struct {
 }
 
 type Payloads struct {
-	BatchSize int // Maximum batch size
-	logs      chan Log
+	batchSize int         // Maximum batch size
+	logs      chan Log    // Channel to stream logs
+	forceSync chan string // Channel to sync logs on intervals
 }
 
 func (p Payloads) Add(log Log) {
 	p.logs <- log
+}
+
+func (p Payloads) sync() {
+	p.forceSync <- "sync"
 }

--- a/pkg/log/payloads.go
+++ b/pkg/log/payloads.go
@@ -1,0 +1,29 @@
+package log
+
+import "time"
+
+type Log struct {
+	UserId int     `json:"user_id"`
+	Total  float64 `json:"total"`
+	Title  string  `json:"title"`
+	Meta   struct {
+		Logins []struct {
+			Time time.Time `json:"time"`
+			Ip   string    `json:"ip"`
+		} `json:"logins"`
+		PhoneNumbers struct {
+			Home   string `json:"home"`
+			Mobile string `json:"mobile"`
+		} `json:"phone_numbers"`
+	} `json:"meta"`
+	Completed bool `json:"completed"`
+}
+
+type Payloads struct {
+	BatchSize int // Maximum batch size
+	logs      chan Log
+}
+
+func (p Payloads) Add(log Log) {
+	p.logs <- log
+}

--- a/pkg/log/syncer.go
+++ b/pkg/log/syncer.go
@@ -1,0 +1,40 @@
+package log
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"time"
+)
+
+func syncPayloadsToTargetEndpoint(payloads []Log, targetEndpoint string) {
+
+	start := time.Now()
+
+	postBody, err := json.Marshal(payloads) // Prepare logs for request
+
+	if err != nil {
+		// Exit the application if JSON can not be serialized
+		panic("JSON could not be marshalled")
+	}
+
+	for count := 0; count < 3; count++ {
+		res, err := http.Post(targetEndpoint, "application/json", bytes.NewBuffer(postBody))
+
+		// If err is nil then request was successful
+		if err == nil {
+			log.Infof("Synced Batch of Size %d which returned status code %d and took %s", len(payloads), res.StatusCode, time.Since(start))
+			break
+		}
+
+		// If syncing failed for 3 times in a row exit the application
+		if count == 2 {
+			panic(fmt.Sprintf("Log syncing failed with error: %s", err))
+		}
+
+		// Wait for 2 seconds before retrying
+		time.Sleep(time.Second * time.Duration(2))
+	}
+}

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -7,11 +7,11 @@ import (
 )
 
 func GetEnvAsInt(name string) int {
-
-	env, err := strconv.Atoi(GetEnvAsString(name))
+	val := GetEnvAsString(name)
+	env, err := strconv.Atoi(val)
 
 	if err != nil {
-		panic("Environment variable could not be parsed as int")
+		panic(fmt.Sprintf("Environment variable %s with value %s could not be parsed as int", name, val))
 	}
 
 	return env


### PR DESCRIPTION
- Using slice for syncing caused race condition to happen when sync to external POST endpoint was going on and interval triggered another sync

- Solution: 
  - Event-based architecture can help with this 
  - This can be achieved in Go via the use of channels using which we can remove the purpose of slices from struct and thus can eliminate the issue of race condition